### PR TITLE
do not create branch if it is already checked out

### DIFF
--- a/src/actions/helpers.ts
+++ b/src/actions/helpers.ts
@@ -83,15 +83,19 @@ export async function commitAndPushBranch({
     logger,
   });
 
-  await git.branch({
-    dir,
-    ref: branch,
-  })
+  const currentBranch = await git.currentBranch({dir})
 
-  await git.checkout({
-    dir,
-    ref: branch,
-  });
+  if (currentBranch !== branch) {
+    await git.branch({
+      dir,
+      ref: branch,
+    })
+  
+    await git.checkout({
+      dir,
+      ref: branch,
+    });
+  }
 
   await git.add({
     dir,


### PR DESCRIPTION
This commit allows to push to the branch that is already checked out in the `azure:repo:push` action. Before, it was failing, saying that the branch already exists