### PR TITLE
Remove repoUrl parameter of azure:repo:clone

### DIFF
--- a/src/actions/run/cloneAzureRepo.ts
+++ b/src/actions/run/cloneAzureRepo.ts
@@ -37,7 +37,7 @@ export const cloneAzureRepoAction = (options: {
     description: "Clone an Azure repository into the workspace directory.",
     schema: {
       input: {
-        required: ["repoUrl", "remoteUrl"],
+        required: ["remoteUrl"],
         type: "object",
         properties: {
           remoteUrl: {


### PR DESCRIPTION
The parameter was required but undefined, fixes #26