### PR TITLE
fix: switch branch with clone instead of checkout

### DIFF
--- a/src/actions/helpers.ts
+++ b/src/actions/helpers.ts
@@ -44,17 +44,14 @@ export async function cloneRepo({
   await git.clone({
     url: remoteUrl,
     dir,
+    ref: branch,
+    noCheckout: false,
   });
 
   await git.addRemote({
     dir,
     remote,
     url: remoteUrl,
-  });
-
-  await git.checkout({
-    dir,
-    ref: branch,
   });
 }
 


### PR DESCRIPTION
# Problem
While trying to clone a repo using the `azure:repo:clone` action, I noticed that I am unable to checkout to a branch other than master.

I tested it out, and found that Git.checkout from core backstage was not working as expected. When utilizing the Git.checkout function, the branch is not found.

# Solution
To solve this, I tried utilizing the clone function instead to clone the intended origin branch straight, so the need for the checkout function is no longer needed.

# Links
- [More context on problem I experienced](https://github.com/Parfuemerie-Douglas/scaffolder-backend-module-azure-repositories/issues/33)
- [Code block I am referencing](https://github.com/Parfuemerie-Douglas/scaffolder-backend-module-azure-repositories/blob/8ed2a9f974426a884062c2715f7c13982316766a/src/actions/helpers.ts#L44-L58)
- #33