### PR TITLE
unified auth on clone/push

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@backstage/backend-common": "^0.22.0",
     "@backstage/backend-plugin-api": "^0.7.0",
     "@backstage/cli": "^0.26.11",
+    "@backstage/cli-common": "^0.1.15",
     "@backstage/config": "^1.2.0",
     "@backstage/errors": "^1.2.3",
     "@backstage/integration": "^1.8.0",
@@ -51,6 +52,7 @@
     "@backstage/plugin-scaffolder-node": "^0.2.9",
     "@backstage/types": "^1.1.1",
     "azure-devops-node-api": "^13.0.0",
+    "isomorphic-git": "^1.29.0",
     "winston": "^3.2.1"
   },
   "devDependencies": {},

--- a/src/actions/helpers.ts
+++ b/src/actions/helpers.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Git } from "@backstage/backend-common";
+import { AuthCallback, GitAuth } from 'isomorphic-git'
 import { Logger } from "winston";
 import * as azdev from "azure-devops-node-api";
 import * as GitApi from "azure-devops-node-api/GitApi";
@@ -23,21 +24,21 @@ import { InputError } from "@backstage/errors";
 
 export async function cloneRepo({
   dir,
-  auth,
+  onAuth,
   logger,
   remote = "origin",
   remoteUrl,
   branch = "main",
 }: {
   dir: string;
-  auth: { username: string; password: string } | { token: string };
+  onAuth: AuthCallback;
   logger: Logger;
   remote?: string;
   remoteUrl: string;
   branch?: string;
 }): Promise<void> {
   const git = Git.fromAuth({
-    ...auth,
+    onAuth: onAuth,
     logger,
   });
 
@@ -57,7 +58,7 @@ export async function cloneRepo({
 
 export async function commitAndPushBranch({
   dir,
-  credentialsProvider,
+  onAuth,
   logger,
   remote = 'origin',
   commitMessage,
@@ -65,7 +66,7 @@ export async function commitAndPushBranch({
   branch = 'scaffolder',
 }: {
   dir: string;
-  credentialsProvider: AzureDevOpsCredentialsProvider;
+  onAuth: AuthCallback;
   logger: Logger;
   remote?: string;
   commitMessage: string;
@@ -78,23 +79,7 @@ export async function commitAndPushBranch({
   };
 
   const git = Git.fromAuth({
-    onAuth: async url => {
-      const credentials = await credentialsProvider.getCredentials({ url });
-
-      logger.info(`Using ${credentials?.type} credentials for ${url}`);
-
-      if (credentials?.type === 'pat') {
-        return { username: "not-empty", password: credentials.token };
-      } else if (credentials?.type === 'bearer') {
-        return {
-          headers: {
-            Authorization: `Bearer ${credentials.token}`,
-          },
-        };
-      }
-
-      throw new InputError(`No token credentials provided for ${url}`);
-    },
+    onAuth: onAuth,
     logger,
   });
 
@@ -168,6 +153,31 @@ export async function createADOPullRequest({
 
   const pr = await gitApiObject.createPullRequest( gitPullRequestToCreate, repoId, project, supportsIterations );
   return pr;
+}
+
+export function onAuthFromCredentials(logger: Logger, provider: AzureDevOpsCredentialsProvider, token?: string): (url: string) => Promise<GitAuth> {
+  return async (url: string) => {
+    const credentials = await provider.getCredentials({ url: url });
+
+    if (token) {
+      logger.info(`Using provided pat for ${url}`);
+      return { username: "not-empty", password: token };
+    } else if (credentials?.type === "pat") {
+      logger.info(`Using ${credentials?.type} credentials for ${url}`);
+      return { username: "not-empty", password: credentials.token };
+    } else if (credentials?.type === "bearer") {
+      logger.info(`Using ${credentials?.type} credentials for ${url}`);
+      return {
+        headers: {
+          Authorization: `Bearer ${credentials.token}`,
+        },
+      };
+    }
+
+    throw new InputError(
+      `No token credentials provided for Azure repository ${url}`
+    );
+  }
 }
 
 export async function updateADOPullRequest({

--- a/src/actions/run/cloneAzureRepo.ts
+++ b/src/actions/run/cloneAzureRepo.ts
@@ -15,14 +15,13 @@
  */
 
 import { resolveSafeChildPath } from "@backstage/backend-plugin-api";
-import { InputError } from "@backstage/errors";
 import {
   DefaultAzureDevOpsCredentialsProvider,
   ScmIntegrationRegistry,
 } from "@backstage/integration";
 import { createTemplateAction } from "@backstage/plugin-scaffolder-node";
 
-import { cloneRepo } from "../helpers";
+import { cloneRepo, onAuthFromCredentials } from "../helpers";
 
 export const cloneAzureRepoAction = (options: {
   integrations: ScmIntegrationRegistry;
@@ -81,24 +80,10 @@ export const cloneAzureRepoAction = (options: {
 
       const provider =
         DefaultAzureDevOpsCredentialsProvider.fromIntegrations(integrations);
-      const credentials = await provider.getCredentials({ url: remoteUrl });
-
-      let auth: { username: string; password: string } | { token: string };
-      if (ctx.input.token) {
-        auth = { username: "not-empty", password: ctx.input.token };
-      } else if (credentials?.type === "pat") {
-        auth = { username: "not-empty", password: credentials.token };
-      } else if (credentials?.type === "bearer") {
-        auth = { token: credentials.token };
-      } else {
-        throw new InputError(
-          `No token credentials provided for Azure repository ${remoteUrl}`
-        );
-      }
 
       await cloneRepo({
         dir: outputDir,
-        auth: auth,
+        onAuth: onAuthFromCredentials(ctx.logger, provider, ctx.input.token),
         logger: ctx.logger,
         remoteUrl: remoteUrl,
         branch: branch,

--- a/src/actions/run/pushAzureRepo.ts
+++ b/src/actions/run/pushAzureRepo.ts
@@ -21,7 +21,7 @@ import {
 } from "@backstage/integration";
 import { createTemplateAction } from "@backstage/plugin-scaffolder-node";
 
-import { commitAndPushBranch } from "../helpers";
+import { commitAndPushBranch, onAuthFromCredentials } from "../helpers";
 import { getRepoSourceDirectory } from "../util";
 
 export const pushAzureRepoAction = (options: {
@@ -75,6 +75,17 @@ export const pushAzureRepoAction = (options: {
             type: "string",
             description: "Sets the default author email for the commit.",
           },
+          server: {
+            type: "string",
+            title: "Server hostname",
+            description:
+              "The hostname of the Azure DevOps service. Defaults to dev.azure.com",
+          },
+          token: {
+            title: "Authenticatino Token",
+            type: "string",
+            description: "The token to use for authorization.",
+          },
         },
       },
     },
@@ -96,15 +107,18 @@ export const pushAzureRepoAction = (options: {
           : config.getOptionalString("scaffolder.defaultAuthor.email"),
       };
 
+      const provider =
+        DefaultAzureDevOpsCredentialsProvider.fromIntegrations(integrations);
+
       await commitAndPushBranch({
         dir: sourcePath,
-        credentialsProvider:
-          DefaultAzureDevOpsCredentialsProvider.fromIntegrations(integrations),
+        onAuth:
+          onAuthFromCredentials(ctx.logger, provider, ctx.input.token),
         logger: ctx.logger,
         commitMessage: gitCommitMessage
           ? gitCommitMessage
           : config.getOptionalString("scaffolder.defaultCommitMessage") ||
-            "Initial commit",
+          "Initial commit",
         gitAuthorInfo,
         branch,
       });


### PR DESCRIPTION
The token input parameter did not work in the push action. The server/token input parameters were also missing from the schema. I've refactored the auth handling to use the same onAuth callback everywhere created the same way from the input token/credentialsprovider.